### PR TITLE
Fix: add missing dependency to the setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setuptools.setup(
           'beautifulsoup4',
           'colorama',
           'lxml',
+          'simpleaudio'
       ],
     packages=setuptools.find_packages(),
     entry_points={


### PR DESCRIPTION
**I've tried to install jakym, and encountered the "ModuleNotFoundErr"**

The `simpleaudio` module isn't listed in package dependencies, although you use it in [player.py](https://github.com/themayankjha/JAKYM/blob/master/jakym/player.py)

```bash
alex:~/ $ pip install jakym                                                                                                                 [19:52:39]
Defaulting to user installation because normal site-packages is not writeable
Collecting jakym
  Using cached jakym-0.4.1-py3-none-any.whl.metadata (6.4 kB)
Requirement already satisfied: yt-dlp in /usr/lib/python3.12/site-packages (from jakym) (2024.4.9)
Requirement already satisfied: pyfiglet in ./.local/lib/python3.12/site-packages (from jakym) (1.0.2)
Requirement already satisfied: requests in /usr/lib/python3.12/site-packages (from jakym) (2.31.0)
Requirement already satisfied: pydub in ./.local/lib/python3.12/site-packages (from jakym) (0.25.1)
Requirement already satisfied: termcolor in ./.local/lib/python3.12/site-packages (from jakym) (2.4.0)
Requirement already satisfied: beautifulsoup4 in /usr/lib/python3.12/site-packages (from jakym) (4.12.3)
Requirement already satisfied: colorama in ./.local/lib/python3.12/site-packages (from jakym) (0.4.6)
Requirement already satisfied: lxml in /usr/lib64/python3.12/site-packages (from jakym) (5.1.0)
Requirement already satisfied: soupsieve>1.2 in /usr/lib/python3.12/site-packages (from beautifulsoup4->jakym) (2.5)
Requirement already satisfied: charset-normalizer<4,>=2 in /usr/lib/python3.12/site-packages (from requests->jakym) (3.3.2)
Requirement already satisfied: idna<4,>=2.5 in /usr/lib/python3.12/site-packages (from requests->jakym) (3.7)
Requirement already satisfied: urllib3<3,>=1.21.1 in /usr/lib/python3.12/site-packages (from requests->jakym) (1.26.18)
Requirement already satisfied: brotli in /usr/lib64/python3.12/site-packages (from yt-dlp->jakym) (1.1.0)
Requirement already satisfied: certifi in /usr/lib/python3.12/site-packages (from yt-dlp->jakym) (2023.5.7)
Requirement already satisfied: mutagen in /usr/lib/python3.12/site-packages (from yt-dlp->jakym) (1.47.0)
Requirement already satisfied: pycryptodomex in /usr/lib64/python3.12/site-packages (from yt-dlp->jakym) (3.20.0)
Requirement already satisfied: websockets in /usr/lib64/python3.12/site-packages (from yt-dlp->jakym) (12.0)
Using cached jakym-0.4.1-py3-none-any.whl (20 kB)
Installing collected packages: jakym
Successfully installed jakym-0.4.1
alex:~/ $ jakym                                                                                                                             [19:52:44]
Traceback (most recent call last):
  File "/home/alex/.local/bin/jakym", line 5, in <module>
    from jakym.__main__ import main
  File "/home/alex/.local/lib/python3.12/site-packages/jakym/__main__.py", line 2, in <module>
    from jakym.playlistmanager import Playlist
  File "/home/alex/.local/lib/python3.12/site-packages/jakym/playlistmanager.py", line 2, in <module>
    import jakym.player as player
  File "/home/alex/.local/lib/python3.12/site-packages/jakym/player.py", line 5, in <module>
    import simpleaudio
ModuleNotFoundError: No module named 'simpleaudio'
```